### PR TITLE
Return early during AJAX requests

### DIFF
--- a/debug-mo-translations.php
+++ b/debug-mo-translations.php
@@ -32,6 +32,9 @@ class Debug_MO_Translations_Controller {
 	 */
 	public function setup() {
 
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX )
+			return;
+
 		if ( ! current_user_can( 'update_core' ) )
 			return;
 


### PR DESCRIPTION
Fixes #1 by not outputting mo info for AJAX requests.
