### PR TITLE
Prepare plugin for i18n

### DIFF
--- a/debug-mo-translations.php
+++ b/debug-mo-translations.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Plugin Name: Debug MO Translations
- * Description: Get translation data: language, files, possible problems.
- * Plugin URI:  https://github.com/closemarketing/debug-mo-translations
- * Version:     1.1
+ * Plugin Name:       Debug MO Translations
+ * Description:       Get translation data: language, files, possible problems.
+ * Plugin URI:        https://github.com/closemarketing/debug-mo-translations
+ * Version:           1.1
  * Requires at least: 4.6
- * Author:      closemarketing
- * Author URI:  https://www.closemarketing.es/
- * Licence:     GPL 2
- * License URI: http://opensource.org/licenses/GPL-2.0
- * Text Domain: debug-mo-translations
+ * Author:            closemarketing
+ * Author URI:        https://www.closemarketing.es/
+ * Licence:           GPL 2
+ * License URI:       http://opensource.org/licenses/GPL-2.0
+ * Text Domain:       debug-mo-translations
  */
 
 /**

--- a/debug-mo-translations.php
+++ b/debug-mo-translations.php
@@ -4,10 +4,12 @@
  * Description: Get translation data: language, files, possible problems.
  * Plugin URI:  https://github.com/closemarketing/debug-mo-translations
  * Version:     1.1
+ * Requires at least: 4.6
  * Author:      closemarketing
  * Author URI:  https://www.closemarketing.es/
  * Licence:     GPL 2
  * License URI: http://opensource.org/licenses/GPL-2.0
+ * Text Domain: debug-mo-translations
  */
 
 /**


### PR DESCRIPTION
Add missing plugin headers for correct i18n:
- [x] `Requires at least`
- [x] `Text Domain`

See https://wp-info.org/tools/checkplugini18n.php?slug=debug-mo-translations

Related to #4 