### PR TITLE
Use in_admin_footer and wp_frontend hooks instead of shutdown hook

### DIFF
--- a/debug-mo-translations.php
+++ b/debug-mo-translations.php
@@ -50,7 +50,14 @@ class Debug_MO_Translations_Controller {
 			3
 		);
 
-		add_action( 'shutdown', array ( $output, 'show' ), 0 );
+		if ( is_admin() ) {
+			/* Print debug in admin. */
+			add_action( 'in_admin_footer', array ( $output, 'show' ), 0 );
+		} else {
+			/* Print debug in frontend. */
+			add_action( 'wp_footer', array ( $output, 'show' ), 0 );
+		}
+
 	}
 }
 
@@ -147,7 +154,17 @@ class Debug_MO_Translations_Output {
 		);
 		$data += $this->get_log();
 
-		print '<div id="wpcontent"><pre>' . join( "\n", $data ) . '</pre></div>';
+		?>
+		<style>
+			#wpfooter {
+				position: relative !important;
+			}
+		</style>
+		<hr>
+		<div class="wrap" style="margin-right: 0">
+			<pre><?php echo join( "\n", $data ); ?></pre>
+		</div>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
This will allow the output to inherit the admin CSS margins without the need to duplicate `#wpcontent`
- [x] Also removes the 100% height inherited by `#wpcontent`
- [x] Overrides `#wpfooter` position to relative
- [x] Adds 'wrap' class to use admin margins with small override (`margin-right: 0`) to perfectly align with other admin content
- [x] Adds horizontal line to separate plugin section

Related to #4 